### PR TITLE
fix level Price

### DIFF
--- a/client/src/Model/Unit.cpp
+++ b/client/src/Model/Unit.cpp
@@ -49,7 +49,7 @@ UnitImpl<type>::UnitImpl(int id, Point location, Owner owner, int health, int le
 
 template <UnitType type>
 int UnitImpl<type>::get_price() const {
-    return INITIAL_PRICE + get_level() * PRICE_INCREASE;
+    return INITIAL_PRICE + (get_level() - 1 ) * PRICE_INCREASE;
 }
 
 template <UnitType type>
@@ -59,7 +59,7 @@ int UnitImpl<type>::get_added_income() const {
 
 template <UnitType type>
 int UnitImpl<type>::get_bounty() const {
-    return INITIAL_BOUNTY + get_level() * BOUNTY_INCREASE;
+    return INITIAL_BOUNTY + ( get_level() -1 )* BOUNTY_INCREASE;
 }
 
 template <UnitType type>


### PR DESCRIPTION
when get bounty for level 1 Light Unit it return 10 instead of 8 and same for other levels 
this is fix for that . 

